### PR TITLE
v0.2.4 - Preserve ref attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.4
+- **Fix:** Preserve `ref` attribute (fixes [`#8`](https://github.com/jedmao/react-bem/issues/8)).
+
+## 0.2.3
+- Badge fixes on README.
+
 ## 0.2.2
 - Defer responsibility of merging modifiers to the HOCs.
 

--- a/README.md
+++ b/README.md
@@ -150,4 +150,5 @@ This project is written in TypeScript, so the TypeScript definitions come for fr
 - `BEMNode`
 - `ReactBEMElement`
 - `ReactBEMElementProps`
+- `ReactElementProps`
 - `ReactRenderResult`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jedmao/react-bem",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "BEM helper functions and HOCs for React.",
   "keywords": [
     "react",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -4,7 +4,11 @@ import {
 } from 'bem-helpers'
 import bemJoin, { BEMJoinOptions } from 'bem-join'
 
-import { ReactBEMElementProps } from './types'
+import {
+	BEMBlockProps,
+	BEMElementProps,
+	ReactElementProps,
+} from './types'
 
 export abstract class Component {
 	static displayName?: string
@@ -19,11 +23,11 @@ export function getDisplayName(ComponentClass: typeof Component) {
 		|| 'Component'
 }
 
-const bemProps = ['block', 'element', 'modifiers']
+const bemProps: ['block', 'element', 'modifiers'] =
+	['block', 'element', 'modifiers']
 export function omitBEMProps<T>(
-	props: T & ReactBEMElementProps,
-): ReactBEMElementProps {
-	// tslint:disable-next-line:no-any
+	props: T & BEMBlockProps & BEMElementProps,
+): ReactElementProps {
 	return omit(props, bemProps) as any
 }
 
@@ -42,9 +46,9 @@ export function isString(value: any): value is String {
 	return typeof value === 'string'
 }
 
-export function omit<T>(obj: T, paths: string[]) {
+export function omit<T, K extends keyof T>(obj: T, paths: K[]) {
 	return Object.keys(obj || {})
-		.filter(k => paths.indexOf(k) === -1)
+		.filter((k: K) => paths.indexOf(k) === -1)
 		.reduce(
 			(accumulator, key) => {
 				accumulator[key] = obj[key]

--- a/src/resolveBEMNode.test.tsx
+++ b/src/resolveBEMNode.test.tsx
@@ -72,6 +72,16 @@ describe('resolveBEMNode', () => {
 		) as JSX.Element)).toMatchSnapshot()
 	})
 
+	it('preserves the ref attribute', () => {
+		const fn = jest.fn()
+		expect((resolveBEMNode(
+			<div ref={fn} />,
+			{
+				block: 'block',
+			}
+		) as any).ref).toBe(fn)
+	})
+
 	it('assigns "block__element" to root node\'s className', () => {
 		expect(shallow(resolveBEMNode(
 			<div />,

--- a/src/resolveBEMNode.tsx
+++ b/src/resolveBEMNode.tsx
@@ -65,9 +65,11 @@ export default function resolveBEMNode(
 		modifiers,
 		{ className: props.className },
 	) : {}
+	const { ref } = node as { ref?: () => void }
 	return (
 		<node.type
 			{...{
+				...(ref ? { ref } : {}),
 				...props,
 				children: resolveChildren(props.children),
 				...classNameProp,

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,9 @@ export interface BEMElementProps {
 }
 
 export interface ReactBEMElementProps<P = {}>
-extends BEMElementProps, React.Props<P> {
+extends BEMElementProps, ReactElementProps<P> {}
+
+export interface ReactElementProps<P = {}>
+extends React.Props<P> {
 	className?: string,
 }


### PR DESCRIPTION
Fixes #8 

## 0.2.4
- **Fix:** Preserve `ref` attribute (fixes [`#8`](https://github.com/jedmao/react-bem/issues/8)).