### PR TITLE
v0.2.5 - Preserve key attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.5
+- **Fix:** Preserve `key` attribute (fixes [`#2`](https://github.com/jedmao/react-bem/issues/2)).
+
 ## 0.2.4
 - **Fix:** Preserve `ref` attribute (fixes [`#8`](https://github.com/jedmao/react-bem/issues/8)).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jedmao/react-bem",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "BEM helper functions and HOCs for React.",
   "keywords": [
     "react",

--- a/src/resolveBEMNode.test.tsx
+++ b/src/resolveBEMNode.test.tsx
@@ -72,6 +72,16 @@ describe('resolveBEMNode', () => {
 		) as JSX.Element)).toMatchSnapshot()
 	})
 
+	it('preserves the key attribute', () => {
+		const key = 'keep-me'
+		expect((resolveBEMNode(
+			<div key={key} />,
+			{
+				block: 'block',
+			}
+		) as any).key).toBe(key)
+	})
+
 	it('preserves the ref attribute', () => {
 		const fn = jest.fn()
 		expect((resolveBEMNode(

--- a/src/resolveBEMNode.tsx
+++ b/src/resolveBEMNode.tsx
@@ -65,10 +65,11 @@ export default function resolveBEMNode(
 		modifiers,
 		{ className: props.className },
 	) : {}
-	const { ref } = node as { ref?: () => void }
+	const { key, ref } = node as { key?: string, ref?: () => void }
 	return (
 		<node.type
 			{...{
+				...(key ? { key } : {}),
 				...(ref ? { ref } : {}),
 				...props,
 				children: resolveChildren(props.children),


### PR DESCRIPTION
Fixes #2 

**Fix:** Preserve `key` attribute (fixes [`#2`](https://github.com/jedmao/react-bem/issues/2)).