### PR TITLE
v0.2.7 - Upgrade @types/react-test-renderer to ^16.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.7
+- **Fix:** Upgrade @types/react-test-renderer 16 to resolve a bug introduced in 15. (fixes [`#21`](https://github.com/jedmao/react-bem/issues/21)).
+
 ## 0.2.6
 - **Fix:** Ensure `resolveBEMNode` can render nested block components (fixes [`#7`](https://github.com/jedmao/react-bem/issues/7)).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jedmao/react-bem",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "BEM helper functions and HOCs for React.",
   "keywords": [
     "react",
@@ -50,7 +50,7 @@
     "@types/prop-types": "^15.5.2",
     "@types/react": "^16.0.9",
     "@types/react-dom": "^16.0.0",
-    "@types/react-test-renderer": "^15.5.4",
+    "@types/react-test-renderer": "^16.0.0",
     "bem-helpers": "^0.9.0",
     "bem-join": "^0.2.0"
   },


### PR DESCRIPTION
Resolves #21 

Resolves an issue introduced with latest version of `@types/react-types-render`, v15