### PR TITLE
Introduce createBEMBlockSFC

### DIFF
--- a/src/__snapshots__/createBEMBlockSFC.test.tsx.snap
+++ b/src/__snapshots__/createBEMBlockSFC.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createBEMBlockSFC merges modifiers prop with root node's modifiers 1`] = `
+<div
+  class="foo foo--mod1 foo--mod2"
+/>
+`;
+
+exports[`createBEMBlockSFC provides BEM block name via context 1`] = `
+Object {
+  "block": "context-block",
+}
+`;

--- a/src/createBEMBlock.tsx
+++ b/src/createBEMBlock.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 
 import { getDisplayName, isFunction } from './helpers'
 import { BEMBlockClass, BEMBlockProps } from './types'
-import resolveBEMNode, { ReactRenderResult } from './resolveBEMNode'
+import resolveRenderedBlock from './resolveRenderedBlock'
 
 export interface BEMBlockProviderContext {
 	/**
@@ -18,12 +18,15 @@ export interface BEMBlockProviderContext {
  * attributes.
  * @param ComponentClass The class to wrap with BEM block functionality.
  */
-export default function createBEMBlock(
-	ComponentClass: BEMBlockClass | React.ComponentClass,
+export default function createBEMBlock<P ={}>(
+	ComponentClass: (
+		BEMBlockClass |
+		React.ComponentClass<P>
+	),
 ) {
 
-	return class Wrapped<P = {}, S = {}>
-	extends (ComponentClass as BEMBlockClass)<P & BEMBlockProps, S> {
+	return class Wrapped<P2 = {}, S = {}>
+	extends (ComponentClass as BEMBlockClass)<P & P2 & BEMBlockProps, S> {
 
 		static displayName = `BEMBlock(${getDisplayName(ComponentClass)})`
 
@@ -42,15 +45,10 @@ export default function createBEMBlock(
 		}
 
 		render() {
-			const {
-				block,
-				modifiers,
-			} = this.props
-			const rendered = super.render.call(this)
-			return rendered && resolveBEMNode(rendered, {
-				block: block as string,
-				modifiers: [rendered.props.modifiers].concat([modifiers]),
-			}) as ReactRenderResult
+			return resolveRenderedBlock(
+				super.render.call(this),
+				this.props,
+			)
 		}
 	}
 }

--- a/src/createBEMBlockSFC.test.tsx
+++ b/src/createBEMBlockSFC.test.tsx
@@ -1,0 +1,45 @@
+import { render } from 'enzyme'
+import * as PT from 'prop-types'
+import * as React from 'react'
+
+import createBEMBlockSFC from './createBEMBlockSFC'
+
+describe('createBEMBlockSFC', () => {
+
+	it('extends input class with a displayName of "BEMBlock(Foo)"', () => {
+		const Foo: React.SFC = () => null
+		const FooBlock = createBEMBlockSFC(Foo)
+		expect(FooBlock.displayName).toEqual('BEMBlock(Foo)')
+	})
+
+	it('provides BEM block name via context', () => {
+		const Foo: React.SFC = (props) => (
+			<div>
+				{props.children}
+			</div>
+		)
+		const FooBlock = createBEMBlockSFC(Foo)
+		const FooItem: React.SFC = (props, context) => {
+			expect(context).toMatchSnapshot()
+			return null
+		}
+		FooItem.contextTypes = {
+			block: PT.string.isRequired,
+		}
+		render(
+			<FooBlock block="context-block">
+				<FooItem />
+			</FooBlock>,
+		)
+	})
+
+	it('merges modifiers prop with root node\'s modifiers', () => {
+		const Foo: React.SFC = () => (
+			<div modifiers="mod1" />
+		)
+		const FooBlock = createBEMBlockSFC(Foo)
+		expect(render(
+			<FooBlock block="foo" modifiers="mod2" />,
+		)).toMatchSnapshot()
+	})
+})

--- a/src/createBEMBlockSFC.ts
+++ b/src/createBEMBlockSFC.ts
@@ -1,0 +1,47 @@
+import * as PT from 'prop-types'
+import * as React from 'react'
+
+import { getDisplayName } from './helpers'
+import { BEMBlockProps } from './types'
+import resolveRenderedBlock from './resolveRenderedBlock'
+
+export interface BEMBlockProviderContext {
+	/**
+	 * BEM block name
+	 */
+	block: string
+}
+
+/**
+ * Wraps an SFC with BEM block functionality, providing the BEM block name
+ * via context and converting block and modifiers attributes into className
+ * attributes.
+ * @param SFC The SFC to wrap with BEM block functionality.
+ */
+export default function createBEMBlockSFC<P ={}>(
+	SFC: React.SFC<P>,
+) {
+
+	return class Wrapped<P2 = {}, S = {}>
+	extends React.Component<any & P & P2 & BEMBlockProps, S> {
+
+		static displayName = `BEMBlock(${getDisplayName(SFC as any)})`
+
+		static childContextTypes = {
+			block: PT.string.isRequired,
+		}
+
+		getChildContext(): BEMBlockProviderContext {
+			return {
+				block: this.props.block as string,
+			}
+		}
+
+		render() {
+			return resolveRenderedBlock(
+				SFC(this.props, this.context),
+				this.props,
+			)
+		}
+	}
+}

--- a/src/createBEMElementSFC.test.tsx
+++ b/src/createBEMElementSFC.test.tsx
@@ -6,10 +6,10 @@ import createBEMElementSFC from './createBEMElementSFC'
 
 describe('createBEMElementSFC', () => {
 
-	it('extends input class with a displayName of "BEMElement(Bar)"', () => {
+	it('extends input class with a displayName of "BEMElementSFC(Bar)"', () => {
 		const Bar: React.SFC = () => null
 		const BarElement = createBEMElementSFC(Bar)
-		expect(BarElement.displayName).toEqual('BEMElement(Bar)')
+		expect(BarElement.displayName).toEqual('BEMElementSFC(Bar)')
 	})
 
 	it('extends input contextTypes with a block validator', () => {

--- a/src/createBEMElementSFC.ts
+++ b/src/createBEMElementSFC.ts
@@ -15,7 +15,7 @@ import { BEMElementProps } from './types'
 export default function createBEMElementSFC<P = {}>(
 	SFC: React.SFC<P>,
 ) {
-	const WrappedSFC: React.SFC = function (
+	const WrappedSFC: React.SFC = function(
 		props: P,
 		context: BEMBlockProviderContext,
 	) {
@@ -26,7 +26,7 @@ export default function createBEMElementSFC<P = {}>(
 		) as JSX.Element | null
 	}
 
-	WrappedSFC.displayName = `BEMElement(${getDisplayName(SFC as any)})`
+	WrappedSFC.displayName = `BEMElementSFC(${getDisplayName(SFC as any)})`
 
 	WrappedSFC.contextTypes = {
 		...(SFC.contextTypes || {}),

--- a/src/resolveRenderedBlock.ts
+++ b/src/resolveRenderedBlock.ts
@@ -1,0 +1,16 @@
+import resolveBEMNode, { ReactRenderResult } from './resolveBEMNode'
+import { BEMBlockProps } from './types'
+
+export default function resolveRenderedBlock<P>(
+	rendered: ReactRenderResult,
+	props: P & BEMBlockProps,
+) {
+	const {
+		block,
+		modifiers,
+	} = props
+	return rendered && resolveBEMNode(rendered, {
+		block: block as string,
+		modifiers: [rendered.props.modifiers].concat([modifiers]),
+	}) as ReactRenderResult
+}


### PR DESCRIPTION
Fixes #4 

The plan is to defer any SFC knowledge to the HOCs instead of `resolveBEMNode`.