### PR TITLE
Disable SourceMaps for distribution.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.1
+- Disable SourceMaps for distribution.
+
 ## 0.4.0
 - **Breaking:** Change BEM props from `block`, `element`, `modifiers` to `bemBlock`, `bemElement` and `bemModifiers` to prevent interface collisions. Fixes [#26](https://github.com/jedmao/react-bem/issues/26).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jedmao/react-bem",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "BEM helper functions and HOCs for React.",
   "keywords": [
     "react",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
-		"outDir": "dist",
-		"declaration": true,
+    "outDir": "dist",
+    "declaration": true,
     "module": "commonjs",
     "target": "es5",
     "lib": ["es6", "dom"],
-		"sourceMap": true,
-		"jsx": "react",
+    "sourceMap": false,
+    "jsx": "react",
     "moduleResolution": "node",
     "rootDir": "src",
     "forceConsistentCasingInFileNames": true,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
+  "sourceMap": true,
   "compilerOptions": {
 		"module": "commonjs"
 	}


### PR DESCRIPTION
SourceMaps were left enabled for distribution which will cause a bunch of warnings.  This PR disables it for distribution but leaves it on for testing.